### PR TITLE
[FIX] fix RTL issues by disabling Fribidi in translate-shell command

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
     "name": "Text Translator",
     "description": "Translation of the text by different translators (currently Google.Translate, Yandex.Translate).\nShortcuts:\n<Super>T - open translator dialog.\n<Super><Shift>T - open translator dialog and translate text from clipboard.\n<Super><Alt>T - open translator dialog and translate from primary selection.\n<Ctrl><Enter> - Translate text.\n<Ctrl><Shift>C - copy translated text to clipboard.\n<Ctrl>S - swap languages.\n<Ctrl>D - reset languages to default\n<Tab> - toggle transliteration of result text.",
     "shell-version": [
-		"3.18"
+        "3.18",
+        "3.20"
     ],
     "url": "https://github.com/awamper/text-translator",
     "settings-schema": "org.gnome.shell.extensions.text-translator",

--- a/translation_providers/google_translation_provider.js
+++ b/translation_providers/google_translation_provider.js
@@ -298,6 +298,7 @@ const Translator = new Lang.Class({
             '--show-original', 'n',
             '--show-languages', 'n',
             '--show-prompt-message', 'n',
+            '--no-bidi',
             source_lang+':'+target_lang,
             text
         ], function(data) {


### PR DESCRIPTION
I've discovered that translate-shell uses `fribidi` library to support RTL languages in terminals which doesn't support RTL natively (GNOME Terminal, XTerm, ... etc) but it also provides an option to disable this behavior which called `--no-bidi` (works great on Konsole for example).

There's no issues with RTL outside the terminal so I noticed that the extension gets RTL text reversed which is not correct, so I added the option `--no-bidi` to the command here to produce the correct output.

I've also added support for GNOME 3.20 in the metadata file and it works great since then.
