### PR TITLE
Restore google tts (for short texts only) and two let keywords missing

### DIFF
--- a/google_tts.js
+++ b/google_tts.js
@@ -1,7 +1,8 @@
 const Lang = imports.lang;
 const Gst = imports.gi.Gst;
 
-const URI = 'https://translate.google.com/translate_tts?ie=UTF-8&q=%s&tl=%s';
+const URI = 'https://translate.google.com/translate_tts?client=tw-ob&ie=UTF-8&total=1&idx=0&textlen=%d&q=%s&tl=%s';
+const MAX_LEN = 100;
 
 const GoogleTTS = new Lang.Class({
     Name: 'GoogleTTS',
@@ -22,9 +23,10 @@ const GoogleTTS = new Lang.Class({
     },
 
     speak: function(text, lang) {
+        let extract = text.substr(0, MAX_LEN - 1);
         this._kill_stream();
 
-        let uri = URI.format(encodeURIComponent(text), lang);
+        let uri = URI.format(extract.length, encodeURIComponent(extract), lang);
         this._player.set_property("uri", uri);
         this._player.set_state(Gst.State.PLAYING);
     },

--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,8 @@
     "name": "Text Translator",
     "description": "Translation of the text by different translators (currently Google.Translate, Yandex.Translate).\nShortcuts:\n<Super>T - open translator dialog.\n<Super><Shift>T - open translator dialog and translate text from clipboard.\n<Super><Alt>T - open translator dialog and translate from primary selection.\n<Ctrl><Enter> - Translate text.\n<Ctrl><Shift>C - copy translated text to clipboard.\n<Ctrl>S - swap languages.\n<Ctrl>D - reset languages to default\n<Tab> - toggle transliteration of result text.",
     "shell-version": [
-		"3.18"
+        "3.18",
+        "3.20"
     ],
     "url": "https://github.com/awamper/text-translator",
     "settings-schema": "org.gnome.shell.extensions.text-translator",

--- a/translation_providers/google_translation_provider.js
+++ b/translation_providers/google_translation_provider.js
@@ -279,7 +279,7 @@ const Translator = new Lang.Class({
             }
 
 
-            output = '';
+            let output = '';
             function _SocketRead(source_object, res) {
                 const [chunk, length] = out_reader.read_upto_finish(res);
                 if (chunk !== null) {
@@ -292,7 +292,7 @@ const Translator = new Lang.Class({
             out_reader.read_line_async(null,null, _SocketRead);
         }
 
-        _this = this;
+        let _this = this;
         let data = exec([
             'trans',
             '--show-original', 'n',

--- a/translation_providers/google_translation_provider.js
+++ b/translation_providers/google_translation_provider.js
@@ -298,6 +298,7 @@ const Translator = new Lang.Class({
             '--show-original', 'n',
             '--show-languages', 'n',
             '--show-prompt-message', 'n',
+            '--no-bidi',
             source_lang+':'+target_lang,
             text
         ], function(data) {

--- a/translation_providers/google_translation_provider.js
+++ b/translation_providers/google_translation_provider.js
@@ -295,9 +295,9 @@ const Translator = new Lang.Class({
         _this = this;
         let data = exec([
             'trans',
-            // '--show-original', 'n',
-            // '--show-languages', 'n',
-            // '--show-prompt-message', 'n',
+            '--show-original', 'n',
+            '--show-languages', 'n',
+            '--show-prompt-message', 'n',
             source_lang+':'+target_lang,
             text
         ], function(data) {

--- a/translator_dialog.js
+++ b/translator_dialog.js
@@ -373,8 +373,10 @@ const TranslatorDialog = new Lang.Class({
         this._listen_target_button.hide();
         this._listen_target_button.actor.connect('clicked',
             Lang.bind(this, function() {
+                let lines_count = this._source.text.split('\n').length;
+                let translation = this._target.text.split('\n').slice(0, lines_count).join('\n');
                 this.google_tts.speak(
-                    this._target.text,
+                    translation,
                     this._text_translator.current_target_lang
                 )
             }))

--- a/translator_dialog.js
+++ b/translator_dialog.js
@@ -385,14 +385,14 @@ const TranslatorDialog = new Lang.Class({
         this._table = new St.Widget({
             layout_manager: this._grid_layout
         });
-        this._grid_layout.attach(this._topbar.actor, 0, 0, 2, 1);
-        this._grid_layout.attach(this._dialog_menu.actor, 1, 0, 1, 1);
-        this._grid_layout.attach(this._source.actor, 0, 2, 1, 1);
-        this._grid_layout.attach(this._target.actor, 1, 2, 1, 1);
-        // this._grid_layout.attach(this._listen_source_button.actor, 0, 3, 1, 1);
-        this._grid_layout.attach(this._chars_counter.actor, 0, 3, 1, 1);
-        // this._grid_layout.attach(this._listen_target_button.actor, 2, 3, 1, 1);
-        this._grid_layout.attach(this._statusbar.actor, 1, 3, 1, 1);
+        this._grid_layout.attach(this._topbar.actor, 0, 0, 4, 1);
+        this._grid_layout.attach(this._dialog_menu.actor, 2, 0, 2, 1);
+        this._grid_layout.attach(this._source.actor, 0, 2, 2, 1);
+        this._grid_layout.attach(this._target.actor, 2, 2, 2, 1);
+        this._grid_layout.attach(this._listen_source_button.actor, 1, 3, 1, 1);
+        this._grid_layout.attach(this._chars_counter.actor, 0, 3, 1, 2);
+        this._grid_layout.attach(this._listen_target_button.actor, 3, 3, 1, 1);
+        this._grid_layout.attach(this._statusbar.actor, 2, 3, 2, 1);
 
         this.contentLayout.add_child(this._table);
 


### PR DESCRIPTION
per https://gist.github.com/alotaiba/1728771#gistcomment-1214330 google api still let below 100 characters queries apply.
This and added items to the query string (text length as one) let the speak feature works.
Here is the result.

Mind the translate-shell has as -speak feature which could get used (though I have not investigated
how it is implemented, gstreamer or not , pulse or plain alsa).

There is also a last commit that only speak the number of lines the input had. The other means to achieve
this are pretty invasive .... this is to strip the dictionary entries from the spoken result.
