### PR TITLE
Fix for issue #18

### DIFF
--- a/translator_dialog.js
+++ b/translator_dialog.js
@@ -215,7 +215,7 @@ const EntryBase = new Lang.Class({
     },
 
     set max_length(length) {
-        length = parseInt(length, 10);
+        length = parseInt(length, 10) || 0;
         this._clutter_text.set_max_length(length);
         this.emit('max-length-changed');
     }


### PR DESCRIPTION
I tracked down the cause of issue #18. It turns out that `length` can be `undefined` making the extension fail.

My fix got the extension up and working again.