### PR TITLE
Fixes: Translation fails when system locale same as target

### DIFF
--- a/translation_provider_base.js
+++ b/translation_provider_base.js
@@ -269,7 +269,10 @@ var TranslationProviderBase = class TranslationProviderBase {
             "--show-prompt-message",
             "n",
             "--no-bidi",
-            source_lang + ":" + target_lang,
+            "-s",
+            source_lang,
+            "-t",
+            target_lang,
             text
         ];
 


### PR DESCRIPTION
```sh
Language preference options:
    -l CODE, -hl CODE, -lang CODE
        Specify your home language.
    -s CODE, -sl CODE, -source CODE, -from CODE
        Specify the source language.
    -t CODES, -tl CODE, -target CODES, -to CODES
        Specify the target language(s), joined by '+'.
```