### PR TITLE
Fix: Modified text box width to prevent box overflow

### DIFF
--- a/translator_dialog.js
+++ b/translator_dialog.js
@@ -469,7 +469,7 @@ var TranslatorDialog = GObject.registerClass({}, class TranslatorDialog extends 
         );
 
         let text_box_width = Math.round(
-            box_width / 2 - 10 // The margin of the translator box
+            box_width / 2 - 45 // The margin of the translator box
         );
         let text_box_height =
             box_height -


### PR DESCRIPTION
on 3.36 shell right text box stands outside of main frame. with 3.34 the problem was not here.
Tried more shell themes, same result.

![image](https://user-images.githubusercontent.com/34240896/80279040-4b82d480-86fb-11ea-88c4-4cc37f5462bf.png)

![image](https://user-images.githubusercontent.com/34240896/80279103-a6b4c700-86fb-11ea-868b-8404006f27da.png)
