### PR TITLE
Fix bugs in gnome 3.38

### DIFF
--- a/buttons_bar.js
+++ b/buttons_bar.js
@@ -1,6 +1,6 @@
 const St = imports.gi.St;
 const Params = imports.misc.params;
-const Tweener = imports.ui.tweener;
+const Tweener = imports.tweener.tweener;
 const ExtensionUtils = imports.misc.extensionUtils;
 
 const Me = ExtensionUtils.getCurrentExtension();
@@ -50,20 +50,14 @@ var ButtonsBarButton = class ButtonsBarButton {
                 style_class: this.params.icon_style
             });
 
-            this._button_content.add(this._icon, {
-                x_fill: false,
-                x_align: St.Align.START
-            });
+            this._button_content.add_child(this._icon);
         }
 
         if (!Utils.is_blank(this._label_text)) {
             this._label = new St.Label();
             this._label.clutter_text.set_markup(this._label_text);
 
-            this._button_content.add(this._label, {
-                x_fill: false,
-                y_align: St.Align.MIDDLE
-            });
+            this._button_content.add_child(this._label);
 
             if (this._icon) {
                 this._label.visible = false;
@@ -222,10 +216,7 @@ var ButtonsBar = class ButtonsBar {
 
     add_button(button) {
         this._buttons.push(button);
-        this.actor.add(button.actor, {
-            x_fill: false,
-            x_align: St.Align.START
-        });
+        this.actor.add_child(button.actor);
     }
 
     clear() {

--- a/chars_counter.js
+++ b/chars_counter.js
@@ -1,5 +1,5 @@
 const St = imports.gi.St;
-const Tweener = imports.ui.tweener;
+const Tweener = imports.tweener.tweener;
 
 var CharsCounter = class CharsCounter {
     constructor() {

--- a/language_chooser.js
+++ b/language_chooser.js
@@ -155,8 +155,6 @@ var LanguageChooser = GObject.registerClass({
             reactive: true,
             x_expand: false,
             y_expand: false,
-            x_fill: false,
-            y_fill: false,
             x_align: St.Align.END,
             y_align: St.Align.MIDDLE
         });

--- a/metadata.json
+++ b/metadata.json
@@ -3,8 +3,8 @@
   "description": "** Needs the package translate-shell **\nTranslation of the text by different translators (currently Google.Translate, Yandex.Translate).\nShortcuts:\nSuper+T - open translator dialog.\nSuper+Shift+T - open translator dialog and translate text from clipboard.\nSuper+Alt+T - open translator dialog and translate from primary selection.\nCtrl+Enter+ - Translate text.\nCtrl+Shift+C - copy translated text to clipboard.\nCtrl+S - swap languages.\nCtrl+D - reset languages to default\nTab+ - toggle transliteration of result text.",
   "name": "Text Translator",
   "settings-schema": "org.gnome.shell.extensions.text-translator",
-  "shell-version": ["3.36"],
+  "shell-version": ["3.38"],
   "url": "https://github.com/gufoe/text-translator",
   "uuid": "text_translator@awamper.gmail.com",
-  "version": 36
+  "version": 38
 }

--- a/status_bar.js
+++ b/status_bar.js
@@ -1,7 +1,7 @@
 const St = imports.gi.St;
 const Gio = imports.gi.Gio;
 const Animation = imports.ui.animation;
-const Tweener = imports.ui.tweener;
+const Tweener = imports.tweener.tweener;
 const Mainloop = imports.mainloop;
 const Params = imports.misc.params;
 const ExtensionUtils = imports.misc.extensionUtils;
@@ -85,7 +85,7 @@ var StatusBar = class StatusBar {
         );
         this._spinner = new Animation.AnimatedIcon(spinner_icon, 16);
 
-        this.actor.add(this._spinner.actor);
+        this.actor.add(this._spinner);
         this.actor.add(this._message_label);
 
         this._messages = {};

--- a/translator_dialog.js
+++ b/translator_dialog.js
@@ -40,11 +40,7 @@ const EntryBase = class EntryBase {
         this.actor.connect("button-press-event", () => {
             this._clutter_text.grab_key_focus();
         });
-        this.actor.add(this.scroll, {
-            x_fill: true,
-            y_fill: true,
-            expand: true
-        });
+        this.actor.add_child(this.scroll);
 
         this._entry = new St.Entry({
             style_class: this.params.entry_style
@@ -74,10 +70,7 @@ const EntryBase = class EntryBase {
         this._box = new St.BoxLayout({
             vertical: true
         });
-        this._box.add(this._entry, {
-            y_align: St.Align.START,
-            y_fill: true
-        });
+        this._box.add_child(this._entry);
 
         this.scroll.add_actor(this._box);
     }
@@ -249,8 +242,6 @@ const ListenButton = class ListenButton {
             style_class: "listen-button",
             x_expand: false,
             y_expand: false,
-            x_fill: false,
-            y_fill: false,
             x_align: St.Align.START,
             y_align: St.Align.MIDDLE
         });


### PR DESCRIPTION
Fix error in installations on gnome 3.38 in Ubuntu 20.10.

About the changes of `.add` into `.add_child`, there is probably some other changes to do to obtain exactly the same appearance, but all seems usable.