### PR TITLE
Migrate to Gnome 40+

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -36,15 +36,8 @@ ExtensionUtils.get_text_translator_extension = function() {
     return Me;
 };
 
-function launch_extension_prefs(uuid) {
-    let appSys = Shell.AppSystem.get_default();
-    let app = appSys.lookup_app("gnome-shell-extension-prefs.desktop");
-    let info = app.get_app_info();
-    let timestamp = global.display.get_current_time_roundtrip();
-    info.launch_uris(
-        ["extension:///" + uuid],
-        global.create_app_launch_context(timestamp, -1)
-    );
+function launch_extension_prefs() {
+    ExtensionUtils.openPrefs();
 }
 
 const TIMEOUT_IDS = {
@@ -118,7 +111,7 @@ const TranslatorPanelButton = GObject.registerClass(
 
             this._menu_open_prefs = new PopupMenu.PopupMenuItem("Preferences");
             this._menu_open_prefs.connect("activate", () => {
-                launch_extension_prefs(Me.uuid);
+                launch_extension_prefs();
             });
             this.menu.addMenuItem(this._menu_open_prefs);
         }
@@ -143,9 +136,9 @@ const TranslatorPanelButton = GObject.registerClass(
 
         set_focus(focus) {
             if (focus) {
-                this.actor.add_style_pseudo_class("active");
+                this.get_first_child().add_style_pseudo_class("active");
             } else {
-                this.actor.remove_style_pseudo_class("active");
+                this.get_first_child().remove_style_pseudo_class("active");
             }
         }
 
@@ -778,7 +771,7 @@ const TranslatorExtension = class TranslatorExtension {
             button_params,
             () => {
                 this.close();
-                launch_extension_prefs(Me.uuid);
+                launch_extension_prefs();
             }
         );
 

--- a/help_dialog.js
+++ b/help_dialog.js
@@ -43,18 +43,8 @@ var HelpDialog = GObject.registerClass({}, class HelpDialog extends ModalDialog.
 
         this._close_button = this._get_close_button();
 
-        this.contentLayout.add(this._close_button, {
-            x_fill: false,
-            x_align: St.Align.END,
-            y_fill: false,
-            y_align: St.Align.START
-        });
-        this.contentLayout.add(this._label, {
-            x_fill: false,
-            x_align: St.Align.START,
-            y_fill: false,
-            y_align: St.Align.END
-        });
+        this.contentLayout.add_child(this._close_button);
+        this.contentLayout.add_child(this._label);
     }
 
     _on_key_press_event(object, event) {

--- a/language_chooser.js
+++ b/language_chooser.js
@@ -172,8 +172,6 @@ var LanguageChooser = GObject.registerClass({
             track_hover: true,
             reactive: true,
             style_class: "translator-language-chooser-button",
-            x_fill: false,
-            y_fill: false,
             x_expand: true,
             y_expand: false
         });

--- a/languages_stats.js
+++ b/languages_stats.js
@@ -5,8 +5,8 @@ const Me = ExtensionUtils.getCurrentExtension();
 const PrefsKeys = Me.imports.prefs_keys;
 const Utils = Me.imports.utils;
 
-const TYPE_SOURCE = "source";
-const TYPE_TARGET = "target";
+var TYPE_SOURCE = "source";
+var TYPE_TARGET = "target";
 
 var LanguagesStats = class LanguagesStats {
     constructor() {

--- a/metadata.json
+++ b/metadata.json
@@ -3,8 +3,8 @@
   "description": "** Needs the package translate-shell **\nTranslation of the text by different translators (currently Google.Translate, Yandex.Translate).\nShortcuts:\nSuper+T - open translator dialog.\nSuper+Shift+T - open translator dialog and translate text from clipboard.\nSuper+Alt+T - open translator dialog and translate from primary selection.\nCtrl+Enter+ - Translate text.\nCtrl+Shift+C - copy translated text to clipboard.\nCtrl+S - swap languages.\nCtrl+D - reset languages to default\nTab+ - toggle transliteration of result text.",
   "name": "Text Translator",
   "settings-schema": "org.gnome.shell.extensions.text-translator",
-  "shell-version": ["3.38"],
+  "shell-version": ["40"],
   "url": "https://github.com/gufoe/text-translator",
   "uuid": "text_translator@awamper.gmail.com",
-  "version": 39
+  "version": 40
 }

--- a/prefs.js
+++ b/prefs.js
@@ -107,7 +107,9 @@ const TranslatorProvidersWidget = GObject.registerClass(
                 this.POSITIONS.last_used_label.rowspan
             );
             this._last_used = new Gtk.Switch({
-                active: false
+                active: false,
+                hexpand: false,
+                halign: Gtk.Align.END,
             });
             this._last_used.connect("notify::active", s => {
                 let active = s.get_active();
@@ -137,7 +139,7 @@ const TranslatorProvidersWidget = GObject.registerClass(
         }
 
         _load_default_source(languages, active_id) {
-            this._source_languages_combo.destroy();
+            this._source_languages_combo.remove_all();
 
             this._source_languages_combo = new Gtk.ComboBoxText();
             this._source_languages_combo.connect("changed", combo => {
@@ -169,14 +171,6 @@ const TranslatorProvidersWidget = GObject.registerClass(
 
             this._source_languages_combo.set_active_id(active_id);
 
-            let source_wrap_width = Math.round(
-                Object.keys(languages).length / 17
-            );
-
-            if (source_wrap_width > 1) {
-                this._source_languages_combo.set_wrap_width(source_wrap_width);
-            }
-
             this._source_languages_combo.show();
 
             this.attach(
@@ -189,7 +183,7 @@ const TranslatorProvidersWidget = GObject.registerClass(
         }
 
         _load_default_target(languages, active_id) {
-            this._target_languages_combo.destroy();
+            this._target_languages_combo.remove_all();
 
             this._target_languages_combo = new Gtk.ComboBoxText();
             this._target_languages_combo.connect("changed", combo => {
@@ -212,14 +206,6 @@ const TranslatorProvidersWidget = GObject.registerClass(
             }
 
             this._target_languages_combo.set_active_id(active_id);
-
-            let target_wrap_width = Math.round(
-                Object.keys(languages).length / 17
-            );
-
-            if (target_wrap_width > 1) {
-                this._target_languages_combo.set_wrap_width(target_wrap_width);
-            }
 
             this._target_languages_combo.show();
 
@@ -346,8 +332,8 @@ const TranslatorKeybindingsWidget = GObject.registerClass(
             );
             this._tree_view.append_column(keybinding_column);
 
-            scrolled_window.add(this._tree_view);
-            this.add(scrolled_window);
+            scrolled_window.set_child(this._tree_view);
+            this.append(scrolled_window);
 
             this._refresh();
         }
@@ -356,7 +342,7 @@ const TranslatorKeybindingsWidget = GObject.registerClass(
             this._store.clear();
 
             for (let settings_key in this._keybindings) {
-                let [key, mods] = Gtk.accelerator_parse(
+                let [_, key, mods] = Gtk.accelerator_parse(
                     Utils.SETTINGS.get_strv(settings_key)[0]
                 );
 
@@ -423,7 +409,9 @@ const TranslatorPrefsGrid = GObject.registerClass(
 
         add_boolean(text, key) {
             let item = new Gtk.Switch({
-                active: this._settings.get_boolean(key)
+                active: this._settings.get_boolean(key),
+                hexpand: false,
+                halign: Gtk.Align.END,
             });
             this._settings.bind(
                 key,
@@ -506,7 +494,7 @@ const TranslatorPrefsGrid = GObject.registerClass(
                 hexpand: true,
                 halign: Gtk.Align.START
             });
-            label.set_line_wrap(wrap || false);
+            label.set_wrap(wrap || false);
 
             this.attach(label, 0, this._rownum, 1, 1); // col, row, colspan, rowspan
             this.attach(widget, 1, this._rownum, 1, 1);
@@ -588,10 +576,10 @@ const TextTranslatorPrefsWidget = GObject.registerClass(
                 transition_duration: 500
             });
             let stack_switcher = new Gtk.StackSwitcher({
-                margin_left: 5,
+                margin_start: 5,
                 margin_top: 5,
                 margin_bottom: 5,
-                margin_right: 5,
+                margin_end: 5,
                 stack: stack
             });
 
@@ -604,8 +592,8 @@ const TextTranslatorPrefsWidget = GObject.registerClass(
                 keybindings.name
             );
 
-            this.add(stack_switcher);
-            this.add(stack);
+            this.append(stack_switcher);
+            this.append(stack);
         }
 
         _get_main_page() {
@@ -738,7 +726,7 @@ function init() {
 
 function buildPrefsWidget() {
     let widget = new TextTranslatorPrefsWidget();
-    widget.show_all();
+    widget.show();
 
     return widget;
 }

--- a/status_bar.js
+++ b/status_bar.js
@@ -9,7 +9,7 @@ const ExtensionUtils = imports.misc.extensionUtils;
 const Me = ExtensionUtils.getCurrentExtension();
 const Utils = Me.imports.utils;
 
-const MESSAGE_TYPES = {
+var MESSAGE_TYPES = {
     error: 0,
     info: 1,
     success: 2
@@ -114,10 +114,10 @@ var StatusBar = class StatusBar {
         this.actor.show();
 
         if (message.has_spinner) {
-            this._spinner.actor.show();
+            this._spinner.get_child().show();
             this._spinner.play();
         } else {
-            this._spinner.actor.hide();
+            this._spinner.get_child().hide();
         }
 
         Tweener.addTween(this.actor, {


### PR DESCRIPTION
I have tested it on my local machine with Gnome Shell 42.4 and Gtk+ 4.7.2. It's working properly.

I am not sure if it does excellent in the previous version, but I still find some little problems:

1. ***help*** dialog and ***language chooser*** dialog cannot be closed by *ESC*. (click button to close is still working).
2. cannot change default shortcuts bindings.

Thankfully, they are not major bugs and can be fixed in a further version.